### PR TITLE
Fixed timing issue

### DIFF
--- a/at09/at09.ino
+++ b/at09/at09.ino
@@ -7,11 +7,10 @@ void setup() {
   Serial.begin(9600);
 
   mySerial.println("AT");
-  while (mySerial.available()) {
-    Serial.write(mySerial.read());
-  }
 }
 
 void loop() {
-  
+  while (mySerial.available()) {
+    Serial.write(mySerial.read());
+  }
 }


### PR DESCRIPTION
Following the blog at https://medium.com/@yostane/using-the-at-09-ble-module-with-the-arduino-3bc7d5cb0ac2 I was unable to get past even the simplest AT test.  I thought my module was faulty!!!  It turns out that mySerial.available() is called too quickly after println("AT") so there is no data to be read and the sketch never checks again.  I've moved the check into the loop so it is continually called.